### PR TITLE
fix for Motorola Lapdock

### DIFF
--- a/keys.c
+++ b/keys.c
@@ -94,10 +94,16 @@ static char *find_kbd_event(void)
 	while(1)
 	{
 		char *r=fgets(s,MAXC,fid);
-		char *h;
+		char *h,*isdock;
 		if (!r) break;
+		h=strstr(r,"Name=");
+		if (h)
+		{
+			isdock=strstr(r,"Motorola Mobility Motorola HD Dock");
+			continue;
+		}
 		h=strstr(r,"Handlers");
-		if (!h) continue;
+		if (!h || isdock) continue;
 		h=strstr(r,"kbd");
 		if (!h) continue;
 		h=strstr(r,"event");


### PR DESCRIPTION
The Lapdock creates two kbd devices. The first , Name="Motorola Mobility Motorola HD Dock", is not the physical keyboard (I suspect it's the infra-red remote on the Multimedia docks they made for the Atrix). The second device is the one we need to monitor for key-presses. Patches to keys.c skip over this first device entry.
