### PR TITLE
drm_gbm: Fall back to trying /dev/dri/card0

### DIFF
--- a/drm_gbm.c
+++ b/drm_gbm.c
@@ -113,6 +113,12 @@ return -1;
 
 void drm_gbm_start () {
 	device = open ("/dev/dri/card1", O_RDWR);
+	if (device < 0)
+	  device = open ("/dev/dri/card0", O_RDWR);
+	if (device < 0) {
+	  puts("Unable to open /dev/dri/card[01]. Is vc4-fkms-v3d enabled?");
+	  exit(1);
+	}
 	resources = drmModeGetResources (device);
 	connector = find_connector (resources);
 	connector_id = connector->connector_id;


### PR DESCRIPTION
On Pi3 with fkms you want to open /dev/dri/card0 so try that if /dev/dri/card1 fails.
Also abort if both fail (likely no fkms driver enabled).