### PR TITLE
penguins: Make levnum unsigned

### DIFF
--- a/penguins.h
+++ b/penguins.h
@@ -127,7 +127,7 @@ typedef struct level_s
 	int delay;
 	int grid;
     float sz;
-	int levnum;
+	unsigned int levnum;
 	int w,h;
 	int numpengs;
 	PENGUIN_T P[MAXPENGS];


### PR DESCRIPTION
Otherwise we crash when pressing P on level 0 (levnum % 50 doesn't do what we want)